### PR TITLE
Perform UPSERT instead of simple INSERT when saving activities

### DIFF
--- a/src/routes/api/activities/+server.ts
+++ b/src/routes/api/activities/+server.ts
@@ -29,7 +29,12 @@ export const POST: RequestHandler = async ({ request, platform }) => {
     const db: D1Database = platform.env.DB;
     const stmt = db.prepare(
       `INSERT INTO strava_activities (id, name, start_date, sport_type, distance, moving_time, elapsed_time, extra_data)
-       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)`
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+       ON CONFLICT(id)
+       DO
+        UPDATE
+        SET name = ?2, start_date = ?3, sport_type = ?4, distance = ?5, extra_data = ?6
+        WHERE id = ?1`
     );
 
     const batch = activities.map((activity: Activity) =>


### PR DESCRIPTION
When saving activities, if the activity does not exist, it performs an ``INSERT``.
If there is an activity with the same ID, it performs an ``UPDATE``.

Resolves #2